### PR TITLE
[add][modify] append Dockerfile and modify README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# npm startで起動するDockerfile
+# Dockerfile to start MCP Server with npx command
 FROM node:22-alpine3.20
 RUN mkdir -p /home/app/soracom-mcp-server
 WORKDIR /home/app/soracom-mcp-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+# npm startで起動するDockerfile
+FROM node:22-alpine3.20
+RUN mkdir -p /home/app/soracom-mcp-server
+WORKDIR /home/app/soracom-mcp-server
+RUN npm install @soracom-labs/soracom-mcp-server
+CMD ["npx", "@soracom-labs/soracom-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -92,6 +92,41 @@ That's it! No installation needed - npx will download and run the server automat
 
 For enhanced security, we recommend creating a SAM (SORACOM Access Management) user with permissions limited to only the necessary API operations, rather than using your root user credentials. Generate the AuthKey ID and Token from this SAM user for use with this MCP server.
 
+#### Using with Docker
+
+You can also run the MCP server using Docker. Build the image with the following command:
+
+```bash
+docker build -t soracom-mcp-server:latest .
+```
+
+Settings are like below:
+
+```json
+{
+  "mcpServers": {
+    "soracom": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "SORACOM_AUTH_KEY_ID",
+        "-e",
+        "SORACOM_AUTH_KEY",
+        "soracom-mcp-server:latest"
+      ],
+      "env": {
+        "SORACOM_AUTH_KEY_ID": "your-key-id",
+        "SORACOM_AUTH_KEY": "your-token",
+        "SORACOM_COVERAGE_TYPE": "jp"
+      }
+    }
+  }
+}
+```
+
 ## Usage
 
 ### Command Naming Convention


### PR DESCRIPTION
This pull request introduces a Docker-based setup for the MCP server, making it easier to deploy and run. The changes include adding a `Dockerfile` for building the Docker image and updating the documentation to guide users on how to use Docker with the MCP server.

### Docker support:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R6): Added a new `Dockerfile` to create a Docker image for the MCP server. The image installs `@soracom-labs/soracom-mcp-server` and starts the server using `npx`.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R95-R129): Updated documentation to include instructions for building and running the MCP server using Docker. This includes a sample configuration for running the server with environment variables for authentication.